### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,17 @@ php:
   - 7.2
   - nightly
 
+matrix:
+  allow_failures:
+    - php: nightly
+
 install:
   - if [[ "$TRAVIS_PHP_VERSION" != "nightly" ]]; then phpenv config-rm xdebug.ini; fi
-  - travis_retry composer self-update
-  - travis_retry composer install --prefer-dist --dev
+  - travis_retry composer install --prefer-dist -n
 
 script:
   - mkdir -p build/logs
-  - phpdbg -qrr vendor/bin/phpunit -c phpunit.xml.dist
+  - phpdbg -qrr vendor/bin/phpunit
 
 after_script:
   - travis_retry vendor/bin/php-coveralls -v

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,11 @@
             "kornrunner\\": "src"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "kornrunner\\": "test"
+        }
+    },
     "require-dev": {
         "phpunit/phpunit": "~7",
         "satooshi/php-coveralls": "~2"

--- a/test/EthTest.php
+++ b/test/EthTest.php
@@ -1,8 +1,10 @@
 <?php
 
-use kornrunner\Eth;
+namespace kornrunner;
 
-class EthTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class EthTest extends TestCase
 {
     /**
      * @dataProvider hashPersonalMessage
@@ -23,14 +25,14 @@ class EthTest extends PHPUnit\Framework\TestCase
 
     public function testNonHexadecimal()
     {
-        $this->expectException('Exception');
+        $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Message should be a hexadecimal');
         Eth::hashPersonalMessage(implode(range('a', 'z')));
     }
 
     public function testOddHex()
     {
-        $this->expectException('Exception');
+        $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Message size cannot be odd');
         Eth::hashPersonalMessage('0xabc');
     }


### PR DESCRIPTION
# Changed log
- Set the ```php-nightly``` in allow_failures setting when executing the Travis build.
- Use the ```::class``` for the ```\Exception``` class.
- The ```composer self-update``` is executed by default in Travis build.
- The ```--dev``` option in composer command is deprecated.- Use the ```composer update --prefer-dist -n``` to update the dependencies for the different PHP versions tests because the ```composer.lock``` will cache the dependencies version when executing the ```composer install```.
- Add the ```autoload-dev``` to load the related ```*Test.php``` automatically.